### PR TITLE
major fixes and improvements for intents and activities

### DIFF
--- a/app/src/main/java/com/jpkhawam/nabu/ArchiveActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/ArchiveActivity.java
@@ -15,8 +15,10 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.navigation.NavigationView;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ArchiveActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
@@ -26,11 +28,12 @@ public class ArchiveActivity extends AppCompatActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_archive);
 
+        DrawerLayout drawerLayout = findViewById(R.id.mainLayout);
         DataBaseHelper dataBaseHelper = new DataBaseHelper(ArchiveActivity.this);
-        ArrayList<Note> allNotes = dataBaseHelper.getAllNotesFromArchive();
+        AtomicReference<ArrayList<Note>> allNotes = new AtomicReference<>(dataBaseHelper.getAllNotesFromArchive());
         RecyclerView notesRecyclerView = findViewById(R.id.notesRecyclerView);
         NotesRecyclerViewAdapter adapter = new NotesRecyclerViewAdapter(this);
-        adapter.setNotes(allNotes);
+        adapter.setNotes(allNotes.get());
         notesRecyclerView.setAdapter(adapter);
 
         TextView emptyNotes = findViewById(R.id.no_archive_text);
@@ -40,10 +43,38 @@ public class ArchiveActivity extends AppCompatActivity
             emptyNotes.setVisibility(View.GONE);
         }
 
+        Intent intentReceived = getIntent();
+        if (intentReceived != null) {
+            long archivedNoteId = intentReceived.getLongExtra(NoteActivity.ARCHIVED_NOTE_IDENTIFIER_KEY, -1);
+            long unarchivedNoteId = intentReceived.getLongExtra(NoteActivity.UNARCHIVED_NOTE_IDENTIFIER_KEY, -1);
+            boolean discardedNote = intentReceived.getBooleanExtra(NoteActivity.DISCARDED_NOTE_KEY, false);
+            if (archivedNoteId != -1) {
+                Snackbar.make(drawerLayout, "Note archived", Snackbar.LENGTH_SHORT)
+                        .setAction("Undo", view -> {
+                            dataBaseHelper.unarchiveNote(archivedNoteId);
+                            allNotes.set(dataBaseHelper.getAllNotesFromArchive());
+                            adapter.setNotes(allNotes.get());
+                            notesRecyclerView.setAdapter(adapter);
+                            emptyNotes.setVisibility(View.GONE);
+                        })
+                        .show();
+            } else if (unarchivedNoteId != -1) {
+                Snackbar.make(drawerLayout, "Note unarchived", Snackbar.LENGTH_SHORT)
+                        .setAction("Undo", view -> {
+                            dataBaseHelper.archiveNote(unarchivedNoteId);
+                            allNotes.set(dataBaseHelper.getAllNotesFromArchive());
+                            adapter.setNotes(allNotes.get());
+                            notesRecyclerView.setAdapter(adapter);
+                            emptyNotes.setVisibility(View.GONE);
+                        })
+                        .show();
+            } else if (discardedNote)
+                Snackbar.make(drawerLayout, "Discarded empty note", Snackbar.LENGTH_SHORT).show();
+        }
+
         Toolbar toolbar = findViewById(R.id.main_toolbar_archive);
         setSupportActionBar(toolbar);
 
-        DrawerLayout drawerLayout = findViewById(R.id.mainLayout);
         NavigationView navigationView = findViewById(R.id.nav_view);
 
         ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(

--- a/app/src/main/java/com/jpkhawam/nabu/DataBaseHelper.java
+++ b/app/src/main/java/com/jpkhawam/nabu/DataBaseHelper.java
@@ -109,7 +109,7 @@ public class DataBaseHelper extends SQLiteOpenHelper {
             String noteContent = cursor.getString(2);
             LocalDateTime dateCreated = LocalDateTime.parse(cursor.getString(5), dateTimeFormatter);
             LocalDateTime dateEdited = LocalDateTime.parse(cursor.getString(6), dateTimeFormatter);
-           // LocalDateTime dateSentToTrash = LocalDateTime.parse(cursor.getString(7), dateTimeFormatter);
+            // LocalDateTime dateSentToTrash = LocalDateTime.parse(cursor.getString(7), dateTimeFormatter);
             // this is where you check if you should just delete the note instead.
             // you could also have a setting to turn it off
             // if (AppSettings.autoDeleteSet()) { check() }
@@ -235,6 +235,21 @@ public class DataBaseHelper extends SQLiteOpenHelper {
     }
 
     /**
+     * SEND A NOTE FROM NOTES_TABLE TO TRASH
+     *
+     * @param noteIdentifier of note to be sent to trash
+     */
+    public void deleteNote(long noteIdentifier) {
+        SQLiteDatabase sqLiteDatabase = this.getWritableDatabase();
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(COLUMN_IN_TRASH, 1);
+        contentValues.put(COLUMN_IN_ARCHIVE, 0);
+        sqLiteDatabase.update(NOTES_TABLE, contentValues,
+                "ID = ?", new String[]{String.valueOf(noteIdentifier)});
+        sqLiteDatabase.close();
+    }
+
+    /**
      * DELETES A NOTE FROM TRASH_TABLE
      *
      * @param note note to be deleted
@@ -264,7 +279,6 @@ public class DataBaseHelper extends SQLiteOpenHelper {
 
     /**
      * MARK A NOTE AS ARCHIVED
-     *
      * @param note note to be archived
      */
     public void archiveNote(Note note) {
@@ -274,6 +288,20 @@ public class DataBaseHelper extends SQLiteOpenHelper {
         contentValues.put(COLUMN_IN_ARCHIVE, 1);
         sqLiteDatabase.update(NOTES_TABLE, contentValues,
                 "ID = ?", new String[]{String.valueOf(note.getNoteIdentifier())});
+        sqLiteDatabase.close();
+    }
+
+    /**
+     * MARK A NOTE AS ARCHIVED
+     * @param noteIdentifier note identifier of note to be archived
+     */
+    public void archiveNote(long noteIdentifier) {
+        SQLiteDatabase sqLiteDatabase = this.getWritableDatabase();
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(COLUMN_IN_TRASH, 0);
+        contentValues.put(COLUMN_IN_ARCHIVE, 1);
+        sqLiteDatabase.update(NOTES_TABLE, contentValues,
+                "ID = ?", new String[]{String.valueOf(noteIdentifier)});
         sqLiteDatabase.close();
     }
 
@@ -318,6 +346,28 @@ public class DataBaseHelper extends SQLiteOpenHelper {
         sqLiteDatabase.update(NOTES_TABLE, contentValues,
                 "ID = ?", new String[]{String.valueOf(noteIdentifier)});
         sqLiteDatabase.close();
+    }
+
+    public boolean isInTrash(Note note) {
+        SQLiteDatabase sqLiteDatabase = getReadableDatabase();
+        String queryString = "SELECT " + COLUMN_IN_TRASH + " FROM " + NOTES_TABLE + " WHERE " + COLUMN_ID + " = " + note.getNoteIdentifier();
+        final Cursor cursor = sqLiteDatabase.rawQuery(queryString, null);
+        cursor.moveToFirst();
+        boolean inTrash = cursor.getInt(0) != 0;
+        sqLiteDatabase.close();
+        cursor.close();
+        return inTrash;
+    }
+
+    public boolean isInArchive(Note note) {
+        SQLiteDatabase sqLiteDatabase = getReadableDatabase();
+        String queryString = "SELECT " + COLUMN_IN_ARCHIVE + " FROM " + NOTES_TABLE + " WHERE " + COLUMN_ID + " = " + note.getNoteIdentifier();
+        final Cursor cursor = sqLiteDatabase.rawQuery(queryString, null);
+        cursor.moveToFirst();
+        boolean inArchive = cursor.getInt(0) != 0;
+        sqLiteDatabase.close();
+        cursor.close();
+        return inArchive;
     }
 
     /**

--- a/app/src/main/java/com/jpkhawam/nabu/MainActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/MainActivity.java
@@ -48,6 +48,8 @@ public class MainActivity extends AppCompatActivity
         Intent intentReceived = getIntent();
         if (intentReceived != null) {
             long archivedNoteId = intentReceived.getLongExtra(NoteActivity.ARCHIVED_NOTE_IDENTIFIER_KEY, -1);
+            long unarchivedNoteId = intentReceived.getLongExtra(NoteActivity.UNARCHIVED_NOTE_IDENTIFIER_KEY, -1);
+            boolean discardedNote = intentReceived.getBooleanExtra(NoteActivity.DISCARDED_NOTE_KEY, false);
             if (archivedNoteId != -1) {
                 Snackbar.make(drawerLayout, "Note archived", Snackbar.LENGTH_SHORT)
                         .setAction("Undo", view -> {
@@ -58,28 +60,40 @@ public class MainActivity extends AppCompatActivity
                             emptyNotes.setVisibility(View.GONE);
                         })
                         .show();
-            }
-
-            Toolbar toolbar = findViewById(R.id.main_toolbar);
-            setSupportActionBar(toolbar);
-
-            NavigationView navigationView = findViewById(R.id.nav_view);
-
-            ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(
-                    this, drawerLayout, toolbar, R.string.open_nav_drawer, R.string.close_nav_drawer);
-
-            drawerLayout.addDrawerListener(actionBarDrawerToggle);
-            actionBarDrawerToggle.syncState();
-            navigationView.setNavigationItemSelectedListener(this);
-
-            FloatingActionButton floatingActionButton = findViewById(R.id.floating_action_button);
-            floatingActionButton.setOnClickListener(view -> {
-                Intent intent = new Intent(this, NoteActivity.class);
-                startActivity(intent);
-            });
-
+            } else if (unarchivedNoteId != -1) {
+                Snackbar.make(drawerLayout, "Note unarchived", Snackbar.LENGTH_SHORT)
+                        .setAction("Undo", view -> {
+                            dataBaseHelper.archiveNote(unarchivedNoteId);
+                            allNotes.set(dataBaseHelper.getAllNotes());
+                            adapter.setNotes(allNotes.get());
+                            notesRecyclerView.setAdapter(adapter);
+                            emptyNotes.setVisibility(View.GONE);
+                        })
+                        .show();
+            } else if (discardedNote)
+                Snackbar.make(drawerLayout, "Discarded empty note", Snackbar.LENGTH_SHORT).show();
         }
+
+        Toolbar toolbar = findViewById(R.id.main_toolbar);
+        setSupportActionBar(toolbar);
+
+        NavigationView navigationView = findViewById(R.id.nav_view);
+
+        ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(
+                this, drawerLayout, toolbar, R.string.open_nav_drawer, R.string.close_nav_drawer);
+
+        drawerLayout.addDrawerListener(actionBarDrawerToggle);
+        actionBarDrawerToggle.syncState();
+        navigationView.setNavigationItemSelectedListener(this);
+
+        FloatingActionButton floatingActionButton = findViewById(R.id.floating_action_button);
+        floatingActionButton.setOnClickListener(view -> {
+            Intent intent = new Intent(this, NoteActivity.class);
+            startActivity(intent);
+        });
+
     }
+
 
     @SuppressLint("NonConstantResourceId")
     @Override

--- a/app/src/main/java/com/jpkhawam/nabu/NoteActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/NoteActivity.java
@@ -24,12 +24,14 @@ public class NoteActivity extends AppCompatActivity {
 
     public static final String NOTE_IDENTIFIER_KEY = "noteIdentifier";
     public static final String ARCHIVED_NOTE_IDENTIFIER_KEY = "archivedNoteId";
+    public static final String UNARCHIVED_NOTE_IDENTIFIER_KEY = "unarchivedNoteId";
+    public static final String DISCARDED_NOTE_KEY = "discardedNote";
     private Note currentNote;
     private CoordinatorLayout parent;
     private TextInputEditText editTextTitle;
     private TextInputEditText editTextContent;
 
-    @SuppressLint({"NonConstantResourceId", "UseCompatLoadingForDrawables"})
+    @SuppressLint({"NonConstantResourceId"})
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -96,15 +98,18 @@ public class NoteActivity extends AppCompatActivity {
 
             MaterialToolbar topAppBar = findViewById(R.id.noteTopBar);
             topAppBar.setNavigationOnClickListener(view -> {
-                Intent outgoingIntent = new Intent(this, MainActivity.class);
-                // redundant yes, but sometimes the app crashes otherwise, "" and null are different
-                if (currentNote.getTitle() == null && currentNote.getContent() == null) {
+                Intent outgoingIntent;
+                if (dataBaseHelper.isInTrash(currentNote))
+                    outgoingIntent = new Intent(this, TrashActivity.class);
+                else if (dataBaseHelper.isInArchive(currentNote))
+                    outgoingIntent = new Intent(this, ArchiveActivity.class);
+                else
+                    outgoingIntent = new Intent(this, MainActivity.class);
+                if ((currentNote.getTitle() == null || currentNote.getTitle().equals("")) &&
+                        (currentNote.getContent() == null || currentNote.getContent().equals(""))) {
                     dataBaseHelper.deleteNote(currentNote);
                     dataBaseHelper.deleteNoteFromTrash(currentNote);
-                }
-                if (currentNote.getTitle().equals("") && currentNote.getContent().equals("")) {
-                    dataBaseHelper.deleteNote(currentNote);
-                    dataBaseHelper.deleteNoteFromTrash(currentNote);
+                    outgoingIntent.putExtra(DISCARDED_NOTE_KEY, true);
                 }
                 startActivity(outgoingIntent);
             });
@@ -113,23 +118,30 @@ public class NoteActivity extends AppCompatActivity {
                     case R.id.note_pin:
                         // pin note
                         return true;
-
                     case R.id.note_add_reminder:
                         // add reminder
                         return true;
-
                     case R.id.note_send_to_archive:
+                        Intent outgoingIntent;
+                        if (dataBaseHelper.isInTrash(currentNote))
+                            outgoingIntent = new Intent(this, TrashActivity.class);
+                        else if (dataBaseHelper.isInArchive(currentNote))
+                            outgoingIntent = new Intent(this, ArchiveActivity.class);
+                        else
+                            outgoingIntent = new Intent(this, MainActivity.class);
                         if ((currentNote.getTitle() == null && currentNote.getContent() == null)
                                 || (currentNote.getTitle().equals("") && currentNote.getContent().equals(""))) {
                             Snackbar.make(parent, "Cannot archive empty note", Snackbar.LENGTH_SHORT).show();
+                        } else if (dataBaseHelper.isInArchive(currentNote)) {
+                            dataBaseHelper.unarchiveNote(currentNote);
+                            outgoingIntent.putExtra(UNARCHIVED_NOTE_IDENTIFIER_KEY, currentNote.getNoteIdentifier());
+                            startActivity(outgoingIntent);
                         } else {
-                            Intent outgoingIntent = new Intent(this, MainActivity.class);
                             dataBaseHelper.archiveNote(currentNote);
                             outgoingIntent.putExtra(ARCHIVED_NOTE_IDENTIFIER_KEY, currentNote.getNoteIdentifier());
                             startActivity(outgoingIntent);
                         }
                         return true;
-
                     default:
                         return false;
                 }


### PR DESCRIPTION
NoteActivity:
- pressing the archive button for an archived note will unarchive it now
- outgoing intent will now match that of the activity the note is in. If you exit a note that was in trash, you'll go back there. same for archive.
- added new intent extras to notify of discarding empty note or unarchiving a note

DataBaseHelper.java:
- added functions isInTrash() and isInArchive() to know if the note belongs to any of those
- added overloaded functions for deleteNote() and archive/unarchive using id instead of note

MainActivity.java / TrashActivity.java / ArchiveActivity.java:
- added the new intents
- fixed the bugs trash and archive were facing