### PR TITLE
Font Size Setting Function Improvement For SettingsActivity and Navigation Drawer

### DIFF
--- a/app/src/main/java/com/jpkhawam/nabu/ArchiveActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/ArchiveActivity.java
@@ -99,7 +99,18 @@ public class ArchiveActivity extends AppCompatActivity
         setSupportActionBar(toolbar);
 
         NavigationView navigationView = findViewById(R.id.nav_view);
-
+        // Get Font Size SharedPreferences
+        String fontSize = settings.getString("settings_fontsize", "Small");
+        // Set NavigationView Font Size According To Font Size SharedPreferences}
+        if (fontSize.equals("Small")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewSmall);
+        }
+        if (fontSize.equals("Medium")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewMedium);
+        }
+        if (fontSize.equals("Large")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewLarge);
+        }
         ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(
                 this, drawerLayout, toolbar, R.string.open_nav_drawer, R.string.close_nav_drawer);
 

--- a/app/src/main/java/com/jpkhawam/nabu/MainActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/MainActivity.java
@@ -32,8 +32,8 @@ public class MainActivity extends AppCompatActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Get Font Type SharedPreferences
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+        // Get Font Type SharedPreferences
         String fontType = settings.getString("settings_fonttype", "Default");
 
         // Add Dyslexia-Friendly fontFamily Style To The Default Theme According To Font Type SharedPreferences
@@ -110,7 +110,18 @@ public class MainActivity extends AppCompatActivity
         setSupportActionBar(toolbar);
 
         NavigationView navigationView = findViewById(R.id.nav_view);
-
+        // Get Font Size SharedPreferences
+        String fontSize = settings.getString("settings_fontsize", "Small");
+        // Set NavigationView Font Size According To Font Size SharedPreferences}
+        if (fontSize.equals("Small")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewSmall);
+        }
+        if (fontSize.equals("Medium")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewMedium);
+        }
+        if (fontSize.equals("Large")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewLarge);
+        }
         ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(
                 this, drawerLayout, toolbar, R.string.open_nav_drawer, R.string.close_nav_drawer);
 

--- a/app/src/main/java/com/jpkhawam/nabu/SettingsActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/SettingsActivity.java
@@ -27,7 +27,7 @@ public class SettingsActivity extends AppCompatActivity implements NavigationVie
         // Get Font Size SharedPreferences
         String fontSize = settings.getString("settings_fontsize", "Small");
 
-        // Set Font Size Value According To Font Size SharedPreferences
+        // Set Settings Font Size Value According To Font Size SharedPreferences
         if (fontSize.equals("Medium")) {
             getTheme().applyStyle(R.style.settingsMediumTheme, false);
         }
@@ -52,7 +52,16 @@ public class SettingsActivity extends AppCompatActivity implements NavigationVie
                 .commit();
 
         NavigationView navigationView = findViewById(R.id.nav_view);
-
+        // Set NavigationView Font Size According To Font Size SharedPreferences}
+        if (fontSize.equals("Small")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewSmall);
+        }
+        if (fontSize.equals("Medium")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewMedium);
+        }
+        if (fontSize.equals("Large")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewLarge);
+        }
         ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(
                 this, drawerLayout, toolbar, R.string.open_nav_drawer, R.string.close_nav_drawer);
 

--- a/app/src/main/java/com/jpkhawam/nabu/TrashActivity.java
+++ b/app/src/main/java/com/jpkhawam/nabu/TrashActivity.java
@@ -100,7 +100,18 @@ public class TrashActivity extends AppCompatActivity
         setSupportActionBar(toolbar);
 
         NavigationView navigationView = findViewById(R.id.nav_view);
-
+        // Get Font Size SharedPreferences
+        String fontSize = settings.getString("settings_fontsize", "Small");
+        // Set NavigationView Font Size According To Font Size SharedPreferences}
+        if (fontSize.equals("Small")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewSmall);
+        }
+        if (fontSize.equals("Medium")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewMedium);
+        }
+        if (fontSize.equals("Large")) {
+            navigationView.setItemTextAppearance(R.style.NavigationViewLarge);
+        }
         ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(
                 this, drawerLayout, toolbar, R.string.open_nav_drawer, R.string.close_nav_drawer);
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Small Font Size Used For NavigationView-->
+    <style name="NavigationViewSmall" parent="TextAppearance.AppCompat.Small">
+        <item name="itemTextAppearance">?textAppearanceTitleSmall</item>
+    </style>
+
+    <!-- Medium Font Size Used For NavigationView-->
+    <style name="NavigationViewMedium" parent="TextAppearance.AppCompat.Medium">
+        <item name="itemTextAppearance">?textAppearanceTitleMedium</item>
+    </style>
+
+    <!-- Large Font Size Used For NavigationView-->
+    <style name="NavigationViewLarge" parent="TextAppearance.AppCompat.Large">
+        <item name="itemTextAppearance">?textAppearanceTitleLarge</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -46,10 +46,12 @@
         <item name="fontFamily">@font/opendyslexic_regular</item>
     </style>
 
+    <!-- Medium Font Size Used For SettingsActivity-->
     <style name="settingsMediumTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:textSize">17sp</item>
     </style>
 
+    <!-- Large Font Size Used For SettingsActivity-->
     <style name="settingsLargeTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:textSize">19sp</item>
     </style>


### PR DESCRIPTION
Addition of theme resources with android:textSize items and 17sp(Medium) and 19sp(Large) attributes to be used for SettingsActivity.

Addition of style resources with itemTextAppearance items and ?textAppearanceTitleSmall, ?textAppearanceTitleMedium, and ?textAppearanceTitleLarge attributes to be used for NavigationView.

SharedPreferences "settings_fontsize" string value is checked to determine the selected font size setting and getTheme().applyStyle() is used for the SettingsActivity font size changes while setItemTextAppearance() is used for the programmatic setting of itemTextAppearance for NavigationView.

Navigation drawer font size change is reflected in every activity that can access the navigation drawer.

SettingsActivity (Small Font Size Selected):
![1](https://user-images.githubusercontent.com/64062732/167798414-5cfc5f3e-d534-4060-b828-a78da6cd78a8.PNG)

SettingsActivity (Medium Font Size Selected):
![2](https://user-images.githubusercontent.com/64062732/167798454-a3125222-584f-45e0-9a41-3811a8c68d6d.PNG)

SettingsActivity (Large Font Size Selected):
![3](https://user-images.githubusercontent.com/64062732/167798615-e7f1a737-ae6f-45de-b316-976df6a834b4.PNG)

Navigation Drawer (Small Font Size Selected):
![4](https://user-images.githubusercontent.com/64062732/167798834-55819a62-d46c-4e75-bd43-ed305090fd48.PNG)

Navigation Drawer (Medium Font Size Selected):
![5](https://user-images.githubusercontent.com/64062732/167798888-067e1589-cf31-40e6-bfcc-852d6c0b97a2.PNG)

Navigation Drawer (Large Font Size Selected):
![6](https://user-images.githubusercontent.com/64062732/167798963-2460037a-2322-4bda-9943-5fc589a541d6.PNG)

